### PR TITLE
Add basic bind type framework.

### DIFF
--- a/buenavista/postgres.py
+++ b/buenavista/postgres.py
@@ -1,4 +1,5 @@
 import datetime
+import dateutil.parser
 import hashlib
 import io
 import json
@@ -484,10 +485,14 @@ class BuenaVistaHandler(socketserver.StreamRequestHandler):
             logger.debug("Format: %d, Type: %d", formats[i], typeoid)
             if formats[i] == 0:
                 decoded = v.decode("utf-8")
-                if decoded.startswith("{") and decoded.endswith("}"):
-                    params.append(decoded[1:-1].split(","))
+                if typeoid == 0:
+                    # strangely this is set to 0 for dates and times
+                    params.append(dateutil.parser.parse(decoded))
                 else:
-                    params.append(decoded)
+                    if decoded.startswith("{") and decoded.endswith("}"):
+                        params.append(decoded[1:-1].split(","))
+                    else:
+                        params.append(decoded)
             else:
                 # see Postgres pg_type_d.h for type OIDs
                 type = TYPE_OIDS.get(typeoid)

--- a/buenavista/postgres.py
+++ b/buenavista/postgres.py
@@ -536,6 +536,8 @@ class BuenaVistaHandler(socketserver.StreamRequestHandler):
             except Exception as e:
                 self.send_error(e, ctx)
                 return
+            param_oids = ctx.stmts[stmt][1]
+            self.send_paramter_description(param_oids)
         else:
             raise Exception(f"Unknown describe type: {describe_type}")
         if query_result.has_results():
@@ -580,6 +582,19 @@ class BuenaVistaHandler(socketserver.StreamRequestHandler):
         else:
             raise Exception(f"Unknown close type: {close_type}")
         self.send_close_complete()
+
+    def send_paramter_description(self, param_oids: List[int]):
+        buf = BVBuffer()
+        for oid in param_oids:
+            buf.write_int32(oid)
+        out = buf.get_value()
+        sig = struct.pack(
+            "!cih",
+            ServerResponse.PARAMETER_DESCRIPTION,
+            len(out) + 6,
+            len(param_oids),
+        )
+        self.wfile.write(sig + out)
 
     def send_row_description(self, query_result: QueryResult):
         buf = BVBuffer()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-dateutil
 duckdb
 fastapi[all]
 psycopg
@@ -6,4 +5,5 @@ psycopg-pool
 pyarrow
 pydantic>=1.2.0,<2.0.0
 pytest
+python-dateutil
 sqlglot

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+dateutil
 duckdb
 fastapi[all]
 psycopg


### PR DESCRIPTION
Allows for new types to be bound.
Found when I tried the Postgres JDBC driver.

Just added a OID->Type mapping and the how to parse the types.
Examples for Integer and Float types. Other types will likely need some more work.
