### PR TITLE
Disable Nagle's

### DIFF
--- a/buenavista/postgres.py
+++ b/buenavista/postgres.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import random
+import socket
 import socketserver
 import struct
 from typing import Dict, List, Optional
@@ -265,6 +266,8 @@ class BVContext:
 
 class BuenaVistaHandler(socketserver.StreamRequestHandler):
     def handle(self):
+        # disable Nangle's
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
         self.r = BVBuffer(self.rfile)
         ctx = None
         try:


### PR DESCRIPTION
I noticed with batching returning data to a client is quite slow.
When I measure the delay it showed almost exactly 40ms - which points to a Nagle's.

Turns out it's indeed due to Nagle's being default on.

(ps. I'll stop now to see if you even want PRs)