### PR TITLE
Handle DBeaver's pg_namespace query casting to REGCLASS

### DIFF
--- a/buenavista/backends/duckdb.py
+++ b/buenavista/backends/duckdb.py
@@ -162,6 +162,13 @@ class DuckDBSession(Session):
             == "SELECT setting FROM pg_catalog.pg_settings WHERE name='max_index_keys'"
         ):
             return "SELECT 32 as setting"
+        elif sql.startswith("SELECT n.oid, n.*, d.description FROM pg_catalog.pg_namespace") \
+                and "CAST('pg_namespace' AS REGCLASS)" in sql:
+            return """SELECT n.oid, n.*, d.description 
+                    FROM pg_catalog.pg_namespace AS n 
+                    LEFT JOIN pg_catalog.pg_description AS d 
+                    ON d.objoid = n.oid AND d.objsubid = 0 AND d.classoid = 'pg_namespace' 
+                    ORDER BY n.nspname"""
         elif "::regclass" in sql:
             return sql.replace("::regclass", "")
         elif "::regtype" in sql:

--- a/buenavista/backends/duckdb.py
+++ b/buenavista/backends/duckdb.py
@@ -164,11 +164,7 @@ class DuckDBSession(Session):
             return "SELECT 32 as setting"
         elif sql.startswith("SELECT n.oid, n.*, d.description FROM pg_catalog.pg_namespace") \
                 and "CAST('pg_namespace' AS REGCLASS)" in sql:
-            return """SELECT n.oid, n.*, d.description 
-                    FROM pg_catalog.pg_namespace AS n 
-                    LEFT JOIN pg_catalog.pg_description AS d 
-                    ON d.objoid = n.oid AND d.objsubid = 0 AND d.classoid = 'pg_namespace' 
-                    ORDER BY n.nspname"""
+            return sql.replace("CAST('pg_namespace' AS REGCLASS)", "'pg_namespace'")
         elif "::regclass" in sql:
             return sql.replace("::regclass", "")
         elif "::regtype" in sql:

--- a/buenavista/backends/duckdb.py
+++ b/buenavista/backends/duckdb.py
@@ -162,9 +162,11 @@ class DuckDBSession(Session):
             == "SELECT setting FROM pg_catalog.pg_settings WHERE name='max_index_keys'"
         ):
             return "SELECT 32 as setting"
-        elif sql.startswith("SELECT n.oid, n.*, d.description FROM pg_catalog.pg_namespace") \
-                and "CAST('pg_namespace' AS REGCLASS)" in sql:
-            return sql.replace("CAST('pg_namespace' AS REGCLASS)", "'pg_namespace'")
+        elif m2 := re.search(r"CAST\('([^']+)' AS REGCLASS\)", sql):
+            name = m2.group(1)
+            target = f"CAST('{name}' AS REGCLASS)"
+            replace = f"'{name}'"
+            return sql.replace(target, replace)
         elif "::regclass" in sql:
             return sql.replace("::regclass", "")
         elif "::regtype" in sql:


### PR DESCRIPTION
Fixes: https://github.com/jwills/buenavista/issues/29

DBeaver sends the following sql to get info regarding tables:

```
"SELECT n.oid, n.*, d.description 
FROM pg_catalog.pg_namespace AS n 
LEFT OUTER JOIN pg_catalog.pg_description AS d 
ON d.objoid = n.oid AND d.objsubid = 0 AND d.classoid = CAST('pg_namespace' AS REGCLASS) ORDER BY nspname"
```

DuckDB does not have a REGCLASS data type though, so it fails. This PR modifies the incoming sql to make it work on duckdb, by removing the cast to REGCLASS.